### PR TITLE
Lowered version for kue and redis compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "async": "^1.2.1",
     "lodash": "^4.6.1",
-    "redis": "^0.12.3",
+    "redis": "^0.12.2",
     "pkginfo": "0.3.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Allows us to not need npm.4pax.com
